### PR TITLE
build: use pipefail to not shadow command errors

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # fail fast
-#set -eo pipefail
+set -eo pipefail
 
 set -eu
 


### PR DESCRIPTION
As we use a function after the commands to format the output, if the first command of the pipe (ex. apt) fails, the second will not, and bash will consider the pipeline successful, not failing the script.