### PR TITLE
Add setting to conditionally change custom repositories behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ $ pack build --buildpack fagiani/apt myapp
     # or add custom apt repos (only required if using packages outside of the standard Ubuntu APT repositories)
     :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
 
+#### Repositories order
+By default, all custom repositories added to the end of `sources.list` file.
+If you want to change this behavior, you can configure it via `BPAPT_CUSTOM_REPO_ORDER` variable:
+
+| Environment variable      | Description                                                                                                                                                                                       |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `BPAPT_CUSTOM_REPO_ORDER` | If set to `append` (default), all custom repositories will be added to the end of `sources.list`. <br> If set to `prepend`, all custom repositories will be added to the start of `sources.list`. |
+
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ $ pack build --buildpack fagiani/apt myapp
 By default, all custom repositories added to the end of `sources.list` file.
 If you want to change this behavior, you can configure it via `BPAPT_CUSTOM_REPO_ORDER` variable:
 
-| Environment variable      | Description                                                                                                                                                                                       |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `BPAPT_CUSTOM_REPO_ORDER` | If set to `append` (default), all custom repositories will be added to the end of `sources.list`. <br> If set to `prepend`, all custom repositories will be added to the start of `sources.list`. |
-
+| `BPAPT_CUSTOM_REPOS` | Description                                                                                   |
+|----------------------|-----------------------------------------------------------------------------------------------|
+| `append`             | All custom repositories will be added to the end of `sources.list`.                           |
+| `prepend`            | All custom repositories will be added to the start of `sources.list`.                         |
+| `custom-only`        | Only custom repos would be added to `sources.list`, any default repositories will be deleted. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to change this behavior, you can configure it via `BPAPT_CUSTOM_REPO
 
 | `BPAPT_CUSTOM_REPOS` | Description                                                                                   |
 |----------------------|-----------------------------------------------------------------------------------------------|
-| `append`             | All custom repositories will be added to the end of `sources.list`.                           |
+| `append` (default)   | All custom repositories will be added to the end of `sources.list`.                           |
 | `prepend`            | All custom repositories will be added to the start of `sources.list`.                         |
 | `custom-only`        | Only custom repos would be added to `sources.list`, any default repositories will be deleted. |
 

--- a/bin/build
+++ b/bin/build
@@ -76,7 +76,17 @@ else
   # like>>    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
   if grep -q -e "^:repo:" Aptfile; then
     topic "Adding custom repositories"
-    cat Aptfile | grep -s -e "^:repo:" | sed 's/^:repo:\(.*\)\s*$/\1/g' >> $APT_SOURCES
+
+    # Capture custom repositories
+    CUSTOM_REPOS=$(grep -s -e "^:repo:" Aptfile | sed 's/^:repo:\(.*\)\s*$/\1/g')
+
+    # Determine whether to prepend or append (default: append)
+    if [ "${BPAPT_CUSTOM_REPO_ORDER:-append}" = "prepend" ]; then
+      { echo "$CUSTOM_REPOS"; echo ""; cat "$APT_SOURCES"; } > "/tmp/sources.list"
+    else
+      { cat "$APT_SOURCES"; echo ""; echo "$CUSTOM_REPOS"; } > "/tmp/sources.list"
+    fi
+    mv "/tmp/sources.list" "$APT_SOURCES"
   fi
 
   APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"

--- a/bin/build
+++ b/bin/build
@@ -79,16 +79,21 @@ else
 
     # Capture custom repositories
     CUSTOM_REPOS=$(grep -s -e "^:repo:" Aptfile | sed 's/^:repo:\(.*\)\s*$/\1/g')
+    # Determine repository order
+    case "${BPAPT_CUSTOM_REPOS:-append}" in
+      "prepend")
+        { echo "$CUSTOM_REPOS"; echo ""; cat "$APT_SOURCES"; } > "/tmp/sources.list"
+        ;;
+      "custom-only")
+        { echo "$CUSTOM_REPOS"; } > "/tmp/sources.list"
+        ;;
+      *)  # Default to append
+        { cat "$APT_SOURCES"; echo ""; echo "$CUSTOM_REPOS"; } > "/tmp/sources.list"
+        ;;
+    esac
 
-    # Determine whether to prepend or append (default: append)
-    if [ "${BPAPT_CUSTOM_REPO_ORDER:-append}" = "prepend" ]; then
-      { echo "$CUSTOM_REPOS"; echo ""; cat "$APT_SOURCES"; } > "/tmp/sources.list"
-    else
-      { cat "$APT_SOURCES"; echo ""; echo "$CUSTOM_REPOS"; } > "/tmp/sources.list"
-    fi
     mv "/tmp/sources.list" "$APT_SOURCES"
   fi
-
   APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
   APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=/dev/null"
 


### PR DESCRIPTION
Fixes #29, #30 

This PR introduces `BPAPT_CUSTOM_REPOS`, allowing users to control how custom repositories are added to the APT sources list. It supports three options:

- **`append` (default)** – Custom repositories are added at the end of `sources.list`.
- **`prepend`** – Custom repositories are added at the beginning of `sources.list`.
- **`custom-only`** – Only custom repositories are included, omitting defaults.

This maintains the existing behavior by default while providing more flexibility.
