### PR TITLE
Ensure sourceparts dir is used when fetching packages

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -53,6 +53,7 @@ echo "$CNB_STACK_ID" > "$apt_layer/STACK"
 APT_CACHE_DIR="$apt_layer/cache"
 APT_STATE_DIR="$apt_layer/state"
 APT_SOURCELIST_DIR="$apt_layer/sources"   # place custom sources.list here
+APT_SOURCEPARTS_DIR="${APT_SOURCELIST_DIR}/sources.list.d" # copy source parts here
 APT_SOURCES="$APT_SOURCELIST_DIR/sources.list"
 APT_VERSION=$(apt-get -v | awk 'NR == 1{ print $2 }')
 
@@ -70,8 +71,10 @@ else
   mkdir -p "$APT_CACHE_DIR/archives/partial"
   mkdir -p "$APT_STATE_DIR/lists/partial"
   mkdir -p "$APT_SOURCELIST_DIR"   # make dir for sources
+  mkdir -p "$APT_SOURCEPARTS_DIR" # make dir for source parts
   cp -f Aptfile "$apt_layer"/Aptfile
   cat "/etc/apt/sources.list" > "$APT_SOURCES"    # no cp here
+  cp /etc/apt/sources.list.d/* "$APT_SOURCEPARTS_DIR"/
   # add custom repositories from Aptfile to sources.list
   # like>>    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
   if grep -q -e "^:repo:" Aptfile; then
@@ -80,7 +83,7 @@ else
   fi
 
   APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
-  APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=/dev/null"
+  APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=$APT_SOURCEPARTS_DIR"
 
   topic "Updating apt caches"
   # Ignore stderr from apt-get update containing: rm: cannot remove '/var/cache/apt/archives/partial/*.deb': Permission denied


### PR DESCRIPTION
This is required for this buildpack to work with ubuntu 24 based stacks, since they now have an empty sources.list file and all the OS sources are on `/etc/apt/sources.list.d/ubuntu.sources`.